### PR TITLE
Fixed non-alphanumeric characters from naming of the test phases

### DIFF
--- a/Sanity/bz1936807-API-function-calls/runtest.sh
+++ b/Sanity/bz1936807-API-function-calls/runtest.sh
@@ -35,7 +35,7 @@ rlJournalStart
         rlRun "rlCheckRecommended; rlCheckRequired" || rlDie 'cannot continue'
     rlPhaseEnd
 
-    rlPhaseStartTest '' && {
+    rlPhaseStartTest && {
         rlRun "make" 0 "Compile source files. If fjson_object_array_del_idx() function is not present, this will fail."
         rlRun "make test" 0 "Execute simple unit test."
     rlPhaseEnd; }


### PR DESCRIPTION
Fixed non-alphanumeric characters from naming of the test phases due failing Tier runs of the CTC testing.